### PR TITLE
Laravel 8.x is supported now

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,19 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '7.3'
             setup: basic
             coverage: no
-            laravel: '~5.6.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.7.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~5.8.0'
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^6.0'
+            laravel: '^7.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## UNRELEASED
+## v3.2.0
 
 ### Changed
 
+- Laravel `8.x` is supported now
+- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)
 - CI completely moved from "Travis CI" to "Github Actions" _(travis builds disabled)_
 - Minimal required PHP version now is `7.2`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM php:7.2.5-alpine
+FROM php:7.3.5-alpine
 
 ENV \
     COMPOSER_ALLOW_SUPERUSER="1" \
     COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:1.10.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:1.10.10 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-2.9.1 1>/dev/null \
+    && pecl install xdebug-2.9.6 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && composer global require 'hirak/prestissimo' --no-interaction --no-suggest --prefer-dist \

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 # Makefile readme (ru): <http://linux.yaroslavl.ru/docs/prog/gnu_make_3-79_russian_manual.html>
 # Makefile readme (en): <https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents>
 
-dc_bin := $(shell command -v docker-compose 2> /dev/null)
-
 SHELL = /bin/sh
-RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)" app
+RUN_APP_ARGS = --rm --user "$(shell id -u):$(shell id -g)"
 
 .PHONY : help build latest install lowest test test-cover 'shell' clean
 .DEFAULT_GOAL : help
@@ -16,25 +14,25 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[32m%-14s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 build: ## Build docker images, required for current package environment
-	$(dc_bin) build
+	docker-compose build
 
 latest: clean ## Install latest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-stable
 
 install: clean ## Install regular php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --prefer-dist --no-interaction --no-suggest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --prefer-dist --no-interaction --no-suggest
 
 lowest: clean ## Install lowest php dependencies
-	$(dc_bin) run $(RUN_APP_ARGS) composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
+	docker-compose run $(RUN_APP_ARGS) app composer update -n --ansi --no-suggest --prefer-dist --prefer-lowest
 
 test: ## Execute php tests and linters
-	$(dc_bin) run $(RUN_APP_ARGS) composer test
+	docker-compose run $(RUN_APP_ARGS) app composer test
 
 test-cover: ## Execute php tests with coverage
-	$(dc_bin) run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
+	docker-compose run --rm --user "0:0" app sh -c 'docker-php-ext-enable xdebug && su $(shell whoami) -s /bin/sh -c "composer phpunit-cover"'
 
 shell: ## Start shell into container with php
-	$(dc_bin) run $(RUN_APP_ARGS) sh
+	docker-compose run $(RUN_APP_ARGS) app sh
 
 clean: ## Remove all dependencies and unimportant files
 	-rm -Rf ./composer.lock ./vendor ./coverage ./tests/temp

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
     "require": {
         "php": "^7.2",
         "symfony/console": "^4.4 || ~5.0",
-        "illuminate/contracts": "^5.5 || ~6.0 || ~7.0",
-        "illuminate/container": "^5.5 || ~6.0 || ~7.0",
-        "illuminate/support": "^5.5 || ~6.0 || ~7.0",
-        "illuminate/view": "^5.5 || ~6.0 || ~7.0"
+        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/container": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0",
+        "illuminate/view": "~6.0 || ~7.0 || ~8.0"
     },
     "require-dev": {
-        "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
+        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^6.4 || ~7.5"
+        "phpunit/phpunit": "^8.5.4 || ^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      PS1: '\[\033[1;32m\]\[\033[1;36m\][\u@docker] \[\033[1;34m\]\w\[\033[0;35m\] \[\033[1;36m\]# \[\033[0m\]'
     volumes:
       - /etc/passwd:/etc/passwd:ro
       - /etc/group:/etc/group:ro

--- a/tests/Commands/VersionCommandTest.php
+++ b/tests/Commands/VersionCommandTest.php
@@ -89,7 +89,7 @@ class VersionCommandTest extends AbstractTestCase
     public function testExceptionThrownWhenWrongSegmentRequested(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~unknown.+segment~i');
+        $this->expectExceptionMessageMatches('~unknown.+segment~i');
 
         $this->execute(['--get-segment' => Str::random()]);
     }
@@ -121,7 +121,7 @@ class VersionCommandTest extends AbstractTestCase
     public function testExceptionThrownWhenWrongVersionSet(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('~wrong.+version~i');
+        $this->expectExceptionMessageMatches('~wrong.+version~i');
 
         $this->execute(['--set-version' => Str::random()]);
     }

--- a/tests/Repositories/ChangelogFileRepositoryTest.php
+++ b/tests/Repositories/ChangelogFileRepositoryTest.php
@@ -94,7 +94,7 @@ EOF;
     public function testExceptionThrowsWhenVersionHeaderCannotBeExtracted(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~Cannot extract latest version~i');
+        $this->expectExceptionMessageMatches('~Cannot extract latest version~i');
 
         $content = <<<'EOF'
 # Changelog
@@ -155,7 +155,7 @@ EOF;
     public function testSetMajorAlwaysThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set major~i');
+        $this->expectExceptionMessageMatches('~cannot set major~i');
 
         (new ChangelogFileRepository(Str::random()))->setMajor(\random_int(1, 100));
     }
@@ -166,7 +166,7 @@ EOF;
     public function testSetMinorAlwaysThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set minor~i');
+        $this->expectExceptionMessageMatches('~cannot set minor~i');
 
         (new ChangelogFileRepository(Str::random()))->setMinor(\random_int(1, 100));
     }
@@ -177,7 +177,7 @@ EOF;
     public function testSetPatchAlwaysThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set patch~i');
+        $this->expectExceptionMessageMatches('~cannot set patch~i');
 
         (new ChangelogFileRepository(Str::random()))->setPatch(\random_int(1, 100));
     }
@@ -188,7 +188,7 @@ EOF;
     public function testSetBuildAlwaysThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set build~i');
+        $this->expectExceptionMessageMatches('~cannot set build~i');
 
         (new ChangelogFileRepository(Str::random()))->setBuild(Str::random());
     }
@@ -199,7 +199,7 @@ EOF;
     public function testGetMajorThrowsExceptionOnFilesystemGet(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~not exist~i');
+        $this->expectExceptionMessageMatches('~not exist~i');
 
         (new ChangelogFileRepository(Str::random(), $this->getFilesystemMockWithGetError()))->getMajor();
     }
@@ -210,7 +210,7 @@ EOF;
     public function testGetMinorThrowsExceptionOnFilesystemGet(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~not exist~i');
+        $this->expectExceptionMessageMatches('~not exist~i');
 
         (new ChangelogFileRepository(Str::random(), $this->getFilesystemMockWithGetError()))->getMinor();
     }
@@ -221,7 +221,7 @@ EOF;
     public function testGetPatchThrowsExceptionOnFilesystemGet(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~not exist~i');
+        $this->expectExceptionMessageMatches('~not exist~i');
 
         (new ChangelogFileRepository(Str::random(), $this->getFilesystemMockWithGetError()))->getPatch();
     }
@@ -232,7 +232,7 @@ EOF;
     public function testGetBuildThrowsExceptionOnFilesystemGet(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~not exist~i');
+        $this->expectExceptionMessageMatches('~not exist~i');
 
         (new ChangelogFileRepository(Str::random(), $this->getFilesystemMockWithGetError()))->getBuild();
     }

--- a/tests/Repositories/ConfigFileRepositoryTest.php
+++ b/tests/Repositories/ConfigFileRepositoryTest.php
@@ -69,7 +69,7 @@ class ConfigFileRepositoryTest extends AbstractTestCase
     public function testSetMajor(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set major~i');
+        $this->expectExceptionMessageMatches('~cannot set major~i');
 
         $this->repository->setMajor(\random_int(1, 100));
     }
@@ -95,7 +95,7 @@ class ConfigFileRepositoryTest extends AbstractTestCase
     public function testSetMinor(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set minor~i');
+        $this->expectExceptionMessageMatches('~cannot set minor~i');
 
         $this->repository->setMinor(\random_int(1, 100));
     }
@@ -121,7 +121,7 @@ class ConfigFileRepositoryTest extends AbstractTestCase
     public function testSetPatch(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot set patch~i');
+        $this->expectExceptionMessageMatches('~cannot set patch~i');
 
         $this->repository->setPatch(\random_int(1, 100));
     }
@@ -252,7 +252,7 @@ class ConfigFileRepositoryTest extends AbstractTestCase
     public function testSetBuildThrowsExceptionOnPuttingError(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot be written~i');
+        $this->expectExceptionMessageMatches('~cannot be written~i');
 
         /** @var m\MockInterface|Filesystem $fs_mock */
         $fs_mock = m::mock(Filesystem::class)

--- a/tests/Repositories/FileRepositoryTest.php
+++ b/tests/Repositories/FileRepositoryTest.php
@@ -328,7 +328,7 @@ class FileRepositoryTest extends AbstractTestCase
     public function testSetMajorThrowsExceptionOnFilesystemPutError(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot be written~i');
+        $this->expectExceptionMessageMatches('~cannot be written~i');
 
         (new FileRepository(Str::random(), $this->getFilesystemMockWithPutError()))->setMajor(\random_int(1, 100));
     }
@@ -347,7 +347,7 @@ class FileRepositoryTest extends AbstractTestCase
     public function testSetMinorThrowsExceptionOnFilesystemPutError(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot be written~i');
+        $this->expectExceptionMessageMatches('~cannot be written~i');
 
         (new FileRepository(Str::random(), $this->getFilesystemMockWithPutError()))->setMinor(\random_int(1, 100));
     }
@@ -366,7 +366,7 @@ class FileRepositoryTest extends AbstractTestCase
     public function testSetPatchThrowsExceptionOnFilesystemPutError(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot be written~i');
+        $this->expectExceptionMessageMatches('~cannot be written~i');
 
         (new FileRepository(Str::random(), $this->getFilesystemMockWithPutError()))->setPatch(\random_int(1, 100));
     }
@@ -385,7 +385,7 @@ class FileRepositoryTest extends AbstractTestCase
     public function testSetBuildThrowsExceptionOnFilesystemPutError(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~cannot be written~i');
+        $this->expectExceptionMessageMatches('~cannot be written~i');
 
         (new FileRepository(Str::random(), $this->getFilesystemMockWithPutError()))->setBuild(Str::random());
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -77,7 +77,7 @@ class ServiceProviderTest extends AbstractTestCase
     public function testExceptionThrownWhenSetWrongDriverClass(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageRegExp('~Driver.+must.+implements.+DriverInterface~');
+        $this->expectExceptionMessageMatches('~Driver.+must.+implements.+DriverInterface~');
 
         /** @var ConfigRepository $config */
         $config = $this->app->make(ConfigRepository::class);


### PR DESCRIPTION
## Description

### Changed

- Laravel `8.x` is supported now
- Minimal Laravel version now is `6.0` (Laravel `5.5` LTS got last security update August 30th, 2020)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
