### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.2', '8.3', '8.4', '8.5']
-        include:
-          - php: '8.2'
-            setup: [basic, lowest]
-            coverage: no
-            laravel: '^11.0'
+        php: ['8.2', '8.3', '8.4', '8.5']        
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -43,7 +38,7 @@ jobs: # Docs: <https://git.io/JvxXE>
         run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
@@ -74,11 +69,11 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v4 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v7 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage/clover.xml
+          files: ./coverage/clover.xml
           flags: php
           fail_ci_if_error: false
 
@@ -87,7 +82,7 @@ jobs: # Docs: <https://git.io/JvxXE>
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           - php: '8.3'
             setup: [basic, lowest]
             coverage: no
-            laravel: '^12.0'
+            laravel: '^11.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.2', '8.3']
+        php: ['8.3', '8.4', '8.5']
         include:
-          - php: '8.2'
+          - php: '8.3'
             setup: [basic, lowest]
             coverage: no
-            laravel: '^10.0'
+            laravel: '^12.0'
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
         include:
-          - php: '8.3'
+          - php: '8.2'
             setup: [basic, lowest]
             coverage: no
             laravel: '^11.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Minimal required PHP version now is `8.3`
 - Minimal Laravel version now is `^11.0`
 - Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Minimal required PHP version now is `8.3`
 - Minimal Laravel version now is `^12.0`
+- Version of `composer` in docker container updated up to `2.10.0`
 - Version of `php` in docker container updated up to `8.4`
 - Update dev dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Minimal required PHP version now is `8.3`
-- Minimal Laravel version now is `^12.0`
+- Minimal Laravel version now is `^11.0`
 - Version of `composer` in docker container updated up to `2.10.0`
-- Version of `php` in docker container updated up to `8.4`
+- Version of `php` in docker container updated up to `8.5`
 - Update dev dependencies
 
 ## v3.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Laravel `13.x` support
+
+### Changed
+
+- Minimal required PHP version now is `8.3`
+- Minimal Laravel version now is `^12.0`
+- Version of `php` in docker container updated up to `8.4`
+- Update dev dependencies
+
 ## v3.8.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-alpine
+FROM php:8.5-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:8.3-alpine
+FROM php:8.4-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.8.9 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.10.0 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
     && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.3.0 1>/dev/null \
+    && pecl install xdebug-3.5.3 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     "require": {
         "php": "^8.3",
         "symfony/console": "^6.0 || ^7.0",
-        "illuminate/contracts": "^12.0 || ^13.0",
-        "illuminate/container": "^12.0 || ^13.0",
-        "illuminate/support": "^12.0 || ^13.0",
-        "illuminate/view": "^12.0 || ^13.0"
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/container": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/view": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
-        "laravel/laravel": "^12.0 || ^13.0",
+        "laravel/laravel": "^11.0 || ^12.0 || ^13.0",
         "mockery/mockery": "^1.6.10",
         "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",

--- a/composer.json
+++ b/composer.json
@@ -14,19 +14,19 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "symfony/console": "^6.0 || ^7.0",
-        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
-        "illuminate/view": "^10.0 || ^11.0 || ^12.0"
+        "illuminate/contracts": "^12.0 || ^13.0",
+        "illuminate/container": "^12.0 || ^13.0",
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/view": "^12.0 || ^13.0"
     },
     "require-dev": {
-        "laravel/laravel": "^10.0 || ^11.0 || ^12.0",
-        "mockery/mockery": "^1.6.5",
-        "phpstan/phpstan": "^1.10.66",
+        "laravel/laravel": "^12.0 || ^13.0",
+        "mockery/mockery": "^1.6.10",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^10.5",
-        "nesbot/carbon": "^2.62 || ^3.1"
+        "nesbot/carbon": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "symfony/console": "^6.0 || ^7.0",
         "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
         "illuminate/container": "^11.0 || ^12.0 || ^13.0",


### PR DESCRIPTION
## Description

### Added

- Laravel `13.x` support

### Changed

- Minimal Laravel version now is `^11.0`
- Version of `composer` in docker container updated up to `2.10.0`
- Version of `php` in docker container updated up to `8.5`
- Update dev dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
